### PR TITLE
Allow user to specify portfolios in query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,14 @@ I used to use Google Finance portfolios as a simple way to watch a few baskets o
 
 ## Customize
 
-Edit the `PORTFOLIOS` variable within `index.html`. For example, if you wanted to see the collection of bank stocks and tech stocks from the above screenshot, you could do this:
+Add portfolio names and symbols as query parameters in the URL. For example, if you wanted to see the collection of bank and tech stocks from the above screenshot, you could use this URL:
+
+https://toddwschneider.com/stocks/?Banks=GS,MS,JPM&Tech=AAPL,GOOGL,MSFT,AMZN
+
+Alternatively, you can edit the `DEFAULT_PORTFOLIOS` variable within `index.html`. For example:
 
 ```js
-const PORTFOLIOS = [
+const DEFAULT_PORTFOLIOS = [
   {'name': 'Banks', 'symbols': ['GS', 'MS', 'JPM']},
   {'name': 'Tech', 'symbols': ['AAPL', 'GOOGL', 'MSFT', 'AMZN']}
 ];

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
     <script>
       'use strict';
 
-      const PORTFOLIOS = [
+      const DEFAULT_PORTFOLIOS = [
         {'name': 'Market ETFs', 'symbols': ['SPY', 'DIA', 'QQQ', 'IWM']},
         {'name': 'Sector ETFs', 'symbols': ['XLF', 'XLK', 'XLV', 'XLP', 'XLY', 'XLE', 'XLB', 'XLI', 'XLU', 'XLRE']},
         {'name': 'Banks', 'symbols': ['GS', 'MS', 'JPM', 'WFC', 'C', 'BAC', 'BCS', 'DB', 'CS', 'RBS']},
@@ -74,6 +74,7 @@
         {'name': 'BigCos', 'symbols': ['XOM', 'WMT', 'JNJ', 'GE', 'T', 'KO', 'DIS', 'MCD', 'PG']}
       ];
 
+      const PORTFOLIOS = portfoliosFromQueryParams() || DEFAULT_PORTFOLIOS;
       const REFRESH_SECONDS = 10;
       const BATCH_SIZE = 100;
       const BASE_URL = 'https://api.iextrading.com/1.0/stock/market/batch';
@@ -187,6 +188,19 @@
             }
           });
         });
+      }
+
+      function portfoliosFromQueryParams() {
+        if (!window.location.search) return;
+
+        let params = new URLSearchParams(window.location.search);
+        let portfolios = [];
+
+        for (let p of params) {
+          portfolios.push({'name': p[0], 'symbols': p[1].split(',')});
+        }
+
+        return portfolios;
       }
 
       function symbolUrl(symbol) {


### PR DESCRIPTION
Allow users to customize portfolios and stocks via query parameters, without having to edit index.html. E.g. https://toddwschneider.com/stocks/?Banks=GS,MS,JPM&Tech=AAPL,GOOGL,MSFT,AMZN

If there are no query parameters, fall back to `DEFAULT_PORTFOLIOS`

In a future PR: add some UI, probably a `<textarea>`, where a user can enter desired portfolios/stocks and then get back a customized permalink