### PR TITLE
Update to use IEX Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stocks!
 
-A free, lightweight, blazing-fast static page to get stock quotes using the [IEX API](https://iextrading.com/developer/). Stocks can be grouped into user-defined portfolios. Quotes update every 10 seconds. No API key required. Everything is contained within index.html, there are no external javascripts or stylesheets to load.
+A free, lightweight, blazing-fast static page to get stock quotes using the [IEX Cloud](https://iexcloud.io/). Stocks can be grouped into user-defined portfolios. Quotes update every 10 seconds. Everything is contained within index.html, there are no external javascripts or stylesheets to load.
 
 See here for a live demo: https://toddwschneider.com/stocks/
 
@@ -33,9 +33,9 @@ If you fork this repo on GitHub and edit index.html to reflect the stocks you wa
 
 You could also save index.html to your local disk and open it in your browser, or upload it to a cloud storage service like S3, GCS, or Azure Storage.
 
-## IEX API
+## IEX Cloud
 
-You do not need to sign up for anything or get an API key to use the [IEX API](https://iextrading.com/developer/docs/), but usage is subject to their [terms of service](https://iextrading.com/api-terms/).
+As of June 2019, you need to sign up for IEX Cloud at https://iexcloud.io/
 
 ## Why aren't the market indices available? (S&P 500, DJIA, NASDAQ)
 

--- a/index.html
+++ b/index.html
@@ -78,10 +78,17 @@
         {'name': 'BigCos', 'symbols': ['XOM', 'WMT', 'JNJ', 'GE', 'BA', 'T', 'KO', 'DIS', 'MCD', 'PG']}
       ];
 
+      // register for a token at https://iexcloud.io/
+      const API_TOKEN = 'YOUR_TOKEN_HERE';
+
+      if (API_TOKEN === 'YOUR_TOKEN_HERE') {
+        alert('You need to register for a token at https://iexcloud.io/');
+      }
+
       const PORTFOLIOS = portfoliosFromQueryParams() || DEFAULT_PORTFOLIOS;
       const REFRESH_SECONDS = 10;
       const BATCH_SIZE = 100;
-      const BASE_URL = 'https://api.iextrading.com/1.0/stock/market/batch';
+      const BASE_URL = 'https://cloud.iexapis.com/stable/stock/market/batch';
       const FAVICON_SYMBOL = 'SPY';
       const FAVICON_BASE_URL = 'https://d3v3cbxkdlyonc.cloudfront.net/stocks';
 
@@ -153,7 +160,7 @@
       function updateDataForBatch(symbols, addTitle) {
         let filters = ['latestPrice', 'change', 'changePercent', 'marketCap'];
         if (addTitle) filters.push('companyName');
-        let url = `${BASE_URL}?types=quote&symbols=${symbols.join(',')}&filter=${filters.join(',')}`;
+        let url = `${BASE_URL}?types=quote&symbols=${symbols.join(',')}&filter=${filters.join(',')}&token=${API_TOKEN}`;
 
         fetch(url).then(response => response.json()).then(json => {
           symbols.forEach(symbol => {
@@ -227,7 +234,7 @@
       }
 
       function formatMarketCap(marketCap) {
-        if (marketCap === null) return '';
+        if (marketCap === null || marketCap === 0) return '';
 
         let value, suffix;
         if (marketCap >= 1e12) {


### PR DESCRIPTION
The old IEX API is deprecated in favor of IEX Cloud: https://iexcloud.io/

a.k.a. "no key required" => "no, key required!"